### PR TITLE
Fix Content Security Policy blocking external media sources

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -33,6 +33,7 @@ app.use(helmet({
       styleSrc: ["'self'", "'unsafe-inline'"],
       scriptSrc: ["'self'"],
       imgSrc: ["'self'", "data:", "https:"],
+      mediaSrc: ["'self'", "https://res.cloudinary.com", "https://cdnt-preview.dzcdn.net"],
       connectSrc: ["'self'", "https://api.deezer.com", "https://api.spotify.com"],
     },
   },


### PR DESCRIPTION
- Add mediaSrc directive to CSP configuration
- Allow Cloudinary videos: https://res.cloudinary.com
- Allow Deezer audio previews: https://cdnt-preview.dzcdn.net
- Resolves CSP violations preventing media playback in production

This fixes the 'Refused to load media' errors that were blocking:
- Yoga video playback from Cloudinary
- Meditation audio previews from Deezer